### PR TITLE
RD: delete column SQL file in delete_account

### DIFF
--- a/cypress/fixtures/delete_account.sql
+++ b/cypress/fixtures/delete_account.sql
@@ -5,9 +5,9 @@ VALUES
   (1, '4cec922b-ecbe-4a46-8511-fc9478c1efd0@mailslurp.com', true, CURRENT_TIMESTAMP, '$2a$10$kzY3LINL6..50Fy9shWCcuNlRfYq0ft5lS.KCcJ5PzrhlWfKK4NIO', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Rebibi', 'Dumama', '0123456789', 'Sbirette');
 
 INSERT INTO organizations
-  (id, siret, verified_email_domains, authorized_email_domains, created_at, updated_at)
+  (id, siret, created_at, updated_at)
 VALUES
-  (1, '21340126800130', '{}', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (1, '21340126800130', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 INSERT INTO users_organizations
   (user_id, organization_id, is_external, verification_type, authentication_by_peers_type, has_been_greeted)


### PR DESCRIPTION
fix : delete column "verified_email_domains" of relation "organizations" because it dosnt exists