### PR TITLE
:wrench: allow sandbox as DEPLOY_ENV

### DIFF
--- a/src/config/env.zod.ts
+++ b/src/config/env.zod.ts
@@ -28,7 +28,7 @@ export const envSchema = z
       zodTrueFalseBoolean().default("False"),
     DATABASE_URL: z.string().url(),
     DEBOUNCE_API_KEY: z.string().optional(),
-    DEPLOY_ENV: z.enum(["preview", "production"]).default("preview"),
+    DEPLOY_ENV: z.enum(["preview", "production", "sandbox"]).default("preview"),
     DISABLE_SECURITY_RESPONSE_HEADERS: zodTrueFalseBoolean().default("False"),
     DISPLAY_TEST_ENV_WARNING: zodTrueFalseBoolean().default("False"),
     DO_NOT_AUTHENTICATE_BROWSER: zodTrueFalseBoolean().default("False"),


### PR DESCRIPTION
Kind of a hot fix to allow the sandbox deployed instance to word :bow: 