### PR TITLE
feat: hide keypass button if not configured

### DIFF
--- a/src/controllers/user/signin-signup.ts
+++ b/src/controllers/user/signin-signup.ts
@@ -13,6 +13,7 @@ import { createAuthenticatedSession } from "../../managers/session/authenticated
 import {
   getAndRemoveLoginHintFromUnauthenticatedSession,
   getEmailFromUnauthenticatedSession,
+  getPartialUserFromUnauthenticatedSession,
   setEmailInUnauthenticatedSession,
   setPartialUserFromUnauthenticatedSession,
   updatePartialUserFromUnauthenticatedSession,
@@ -84,11 +85,13 @@ export const postStartSignInController = async (
       email,
       userExists,
       hasAPassword,
+      hasWebauthnConfigured,
       needsInclusionconnectWelcomePage,
     } = await startLogin(login);
     setPartialUserFromUnauthenticatedSession(req, {
       email,
       needsInclusionconnectWelcomePage,
+      hasWebauthnConfigured,
     });
 
     if (needsInclusionconnectWelcomePage) {
@@ -158,11 +161,15 @@ export const getSignInController = async (
   next: NextFunction,
 ) => {
   try {
+    const { email, hasWebauthnConfigured } =
+      getPartialUserFromUnauthenticatedSession(req);
+
     return res.render("user/sign-in", {
       pageTitle: "Accéder au compte",
       notifications: await getNotificationsFromRequest(req),
       csrfToken: csrfToken(req),
-      email: getEmailFromUnauthenticatedSession(req),
+      email,
+      showPasskeySection: hasWebauthnConfigured,
     });
   } catch (error) {
     next(error);

--- a/src/controllers/webauthn.ts
+++ b/src/controllers/webauthn.ts
@@ -144,7 +144,7 @@ export const getSignInWithPasskeyController = async (
   }
 };
 
-export const getGenerateAuthenticationOptions =
+export const getGenerateAuthenticationOptionsControllerFactory =
   (isSecondFactorAuthentication: boolean) =>
   async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -168,10 +168,10 @@ export const getGenerateAuthenticationOptions =
   };
 
 export const getGenerateAuthenticationOptionsForFirstFactorController =
-  getGenerateAuthenticationOptions(false);
+  getGenerateAuthenticationOptionsControllerFactory(false);
 
 export const getGenerateAuthenticationOptionsForSecondFactorController =
-  getGenerateAuthenticationOptions(true);
+  getGenerateAuthenticationOptionsControllerFactory(true);
 
 export const postVerifyAuthenticationController =
   (isSecondFactorVerification: boolean) =>

--- a/src/managers/session/unauthenticated.ts
+++ b/src/managers/session/unauthenticated.ts
@@ -34,6 +34,7 @@ export const getPartialUserFromUnauthenticatedSession = (req: Request) => {
     email: req.session.email,
     needsInclusionconnectWelcomePage:
       req.session.needsInclusionconnectWelcomePage,
+    hasWebauthnConfigured: req.session.hasWebauthnConfigured,
   };
 };
 export const setPartialUserFromUnauthenticatedSession = (
@@ -41,11 +42,17 @@ export const setPartialUserFromUnauthenticatedSession = (
   {
     email,
     needsInclusionconnectWelcomePage,
-  }: { email: string; needsInclusionconnectWelcomePage: boolean },
+    hasWebauthnConfigured,
+  }: {
+    email: string;
+    needsInclusionconnectWelcomePage: boolean;
+    hasWebauthnConfigured: boolean;
+  },
 ) => {
   req.session.email = email;
   req.session.needsInclusionconnectWelcomePage =
     needsInclusionconnectWelcomePage;
+  req.session.hasWebauthnConfigured = hasWebauthnConfigured;
 };
 export const updatePartialUserFromUnauthenticatedSession = async (
   req: Request,

--- a/src/managers/user.ts
+++ b/src/managers/user.ts
@@ -38,6 +38,7 @@ import {
   isPasswordSecure,
   validatePassword,
 } from "../services/security";
+import { isWebauthnConfiguredForUser } from "./webauthn";
 
 export const startLogin = async (
   email: string,
@@ -45,6 +46,7 @@ export const startLogin = async (
   email: string;
   userExists: boolean;
   hasAPassword: boolean;
+  hasWebauthnConfigured: boolean;
   needsInclusionconnectWelcomePage: boolean;
 }> => {
   const user = await findByEmail(email);
@@ -55,6 +57,7 @@ export const startLogin = async (
       email,
       userExists: true,
       hasAPassword: !!user.encrypted_password,
+      hasWebauthnConfigured: await isWebauthnConfiguredForUser(user.id),
       needsInclusionconnectWelcomePage:
         user?.needs_inclusionconnect_welcome_page,
     };
@@ -75,6 +78,7 @@ export const startLogin = async (
     email,
     userExists: false,
     hasAPassword: false,
+    hasWebauthnConfigured: false,
     needsInclusionconnectWelcomePage: false,
   };
 };

--- a/src/types/express-session.d.ts
+++ b/src/types/express-session.d.ts
@@ -2,6 +2,7 @@ export interface UnauthenticatedSessionData {
   email?: string;
   loginHint?: string;
   needsInclusionconnectWelcomePage?: boolean;
+  hasWebauthnConfigured?: boolean;
   interactionId?: string;
   mustReturnOneOrganizationInPayload?: boolean;
   mustUse2FA?: boolean;

--- a/src/views/user/sign-in.ejs
+++ b/src/views/user/sign-in.ejs
@@ -57,6 +57,17 @@
                 <a href="/users/reset-password" class="fr-link">Mot de passe oublié ?</a>
             </p>
         </form>
+        <% if (showPasskeySection) { %>
+
+        <p class="fr-hr-or">ou</p>
+
+        <a
+            class="fr-btn fr-mb-2w btn--fullwidth fr-btn--secondary fr-btn--icon-left fr-icon-lock-unlock-line"
+            href="/users/sign-in-with-passkey"
+        >
+            Se connecter avec une clé d’accès
+        </a>
+        <% } %>
 
         <p class="fr-hr-or">ou</p>
 
@@ -70,15 +81,6 @@
                 Recevoir un lien d’identification
             </button>
         </form>
-
-        <p class="fr-hr-or">ou</p>
-
-        <a
-            class="fr-btn fr-mb-2w btn--fullwidth fr-btn--secondary fr-btn--icon-left fr-icon-lock-unlock-line"
-            href="/users/sign-in-with-passkey"
-        >
-            Se connecter avec une clé d’accès
-        </a>
 
         <div class="card-button-container fr-mt-2w">
             <span>


### PR DESCRIPTION
This PR hide the option to login with passkey if the user has not configured it.

Without Passkey configured:

![image](https://github.com/user-attachments/assets/4f74d782-c981-4783-be9a-ad37667151bf)

With Passkey configured:

![image](https://github.com/user-attachments/assets/48236adb-3641-415c-ab2c-19578adc79b4)
