### PR TITLE
chore(link): replace intern help link with external crisp link

### DIFF
--- a/src/views/partials/footer.ejs
+++ b/src/views/partials/footer.ejs
@@ -27,7 +27,7 @@
         <div class="fr-footer__bottom">
             <ul class="fr-footer__bottom-list">
                 <li class="fr-footer__bottom-item">
-                    <a class="fr-footer__bottom-link" href="/help">Aide</a>
+                    <a class="fr-footer__bottom-link" href="https://agentconnect.crisp.help/fr/">Aide</a>
                 </li>
                 <li class="fr-footer__bottom-item">
                     <a class="fr-footer__bottom-link" href="https://moncomptepro.beta.gouv.fr/">À propos</a>

--- a/src/views/partials/header.ejs
+++ b/src/views/partials/header.ejs
@@ -31,7 +31,7 @@
                             <li>
                                 <a
                                     class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-icon-question-fill fr-btn--icon-left"
-                                    href="/help"
+                                    href="https://agentconnect.crisp.help/fr/"
                                 >
                                     Aide
                                 </a>


### PR DESCRIPTION
Première pull request qui renvoient les sections "aide" vers le helpdesk de crisp. 

Dans une seconde PR il faudra cleaner le code et supprimer la page aide interne (qui pour l'instant est encore nécessaire pour les parcours) 