### PR TITLE
Omit devDependencies again in fixtures workflow

### DIFF
--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           cache: "npm"
           node-version-file: package.json
-      - run: npm ci --omit=dev
+      - run: npm ci --omit=dev # omit dev dependencies to simulate deployed environment
       - run: npm run migrate up
       - run: npm run fixtures:load-ci -- scripts/fixtures.sql
       - run: npm run update-organization-info -- 500

--- a/.github/workflows/fixtures.yml
+++ b/.github/workflows/fixtures.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           cache: "npm"
           node-version-file: package.json
-      - run: npm ci
+      - run: npm ci --omit=dev
       - run: npm run migrate up
       - run: npm run fixtures:load-ci -- scripts/fixtures.sql
       - run: npm run update-organization-info -- 500


### PR DESCRIPTION
In #718, the `fixtures.yml` workflow broke when I added a call to `dotenvx` in the `migrate` script, while `dotenvx` was only a `devDependency`  which was not installed by that workflow. I "fixed" it by enabling `devDependencies` in that workflow.

That was tragic mistake, as what that workflow failure was telling us was that the `migrate` script was no longer able to run in a production-like environment.

Fortunately, the problem was caught in the staging environment, and properly fixed in #760 by moving `dotenvx` to `dependencies`.

This PR completes the reversal by reinstating the `--omit-dev` flag in the `fixtures.yml` workflow, so that future similar issues are caught sooner.

