### PR TITLE
feat(database): remove already verified domain email

### DIFF
--- a/migrations/1731434032350_delete-already-verified-email-domain.cjs
+++ b/migrations/1731434032350_delete-already-verified-email-domain.cjs
@@ -1,0 +1,47 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+exports.shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.up = (pgm) => {
+  return pgm.db.query(`
+    DELETE
+    FROM
+      email_domains
+    WHERE
+      verification_type IS NULL
+      AND (organization_id, domain) IN (
+        SELECT
+          organization_id,
+          domain
+        FROM
+          email_domains
+        GROUP BY
+          organization_id,
+          domain
+        HAVING
+          COUNT(
+            CASE
+              WHEN verification_type IS NULL THEN 1
+            END
+          ) > 0
+          AND COUNT(
+            CASE
+              WHEN verification_type IS NOT NULL THEN 1
+            END
+          ) > 0
+      );
+  `);
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+exports.down = (pgm) => {};


### PR DESCRIPTION
<div align="center">
    <img src="https://media.giphy.com/media/1Hu8vnu6zZaHpJfpCK/giphy.gif">
</div>

---

```sql
SELECT
  COUNT(*)
FROM
  email_domains
WHERE
  verification_type IS NULL
  AND (organization_id, DOMAIN) IN (
    SELECT
      organization_id,
      DOMAIN
    FROM
      email_domains
    GROUP BY
      organization_id,
      DOMAIN
    HAVING
      COUNT(
        CASE
          WHEN verification_type IS NULL THEN 1
        END
      ) > 0
      AND COUNT(
        CASE
          WHEN verification_type IS NOT NULL THEN 1
        END
      ) > 0
  );
```

And found **2285** entries to remove :eye: (12/11/2024)