### PR TITLE
fix(www): remove explicit catch of weak password on signup

### DIFF
--- a/src/controllers/user/signin-signup.ts
+++ b/src/controllers/user/signin-signup.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/node";
 import type { NextFunction, Request, Response } from "express";
 import { z, ZodError } from "zod";
 import { FEATURE_DISPLAY_TEST_ENV_WARNING } from "../../config/env";
@@ -266,7 +265,6 @@ export const postSignUpController = async (
       );
     }
     if (error instanceof WeakPasswordError) {
-      Sentry.captureException(error);
       return res.redirect(`/users/sign-up?notification=weak_password`);
     }
     if (error instanceof LeakedPasswordError) {


### PR DESCRIPTION
<div align="center">
    <img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMnZvbGsxdGNqZDJhNjB2dG01ajdydnd2aG80d3MybmhmMndzaTMxNiZlcD12MV9naWZzX3NlYXJjaCZjdD1n/QoZunxgU0Z1i8/giphy.gif">
</div>

---

![image](https://github.com/user-attachments/assets/33ea6fb9-a4e2-4b9b-a902-9c63caaebbb9)

\following #779 