### PR TITLE
fix(authent): add destroy session when user dosnt exists to avoid error

### DIFF
--- a/src/middlewares/user.ts
+++ b/src/middlewares/user.ts
@@ -168,9 +168,13 @@ export const checkUserTwoFactorAuthMiddleware = async (
           return res.redirect("/users/2fa-sign-in");
         }
       }
-
       return next();
     } catch (error) {
+      if (error instanceof UserNotFoundError) {
+        // The user has an active session but is not in the database anymore
+        await destroyAuthenticatedSession(req);
+        next(new HttpErrors.Unauthorized());
+      }
       next(error);
     }
   });


### PR DESCRIPTION
With @douglasduteil, we discovered an error loop. When the confirmation email isn't sent, you can't go back because a session is created but the user doesn't exist. This PR allows you to delete the session when you go back!