### PR TITLE
feat(modale): replaces modal announcement of new name by modal satisfaction questionnaire

### DIFF
--- a/assets/css/imports/custom.css
+++ b/assets/css/imports/custom.css
@@ -61,3 +61,40 @@
   z-index: 1000;
   position: absolute;
 }
+/* -----------------------------------------------------------------
+
+  CUSTOMISE ICON NOTICE COMPONENT - it's a temporary questionnaire for new PC service
+
+----------------------------------------------------------------- */
+
+.ac-notice--info
+  .ac-notice__title:not([class^="fr-icon-"]):not([class*=" fr-icon-"]):not(
+    [class^="fr-fi-"]
+  ):not([class*=" fr-fi-"]):before {
+  -webkit-mask-image: url("@gouvfr/dsfr/dist/icons/system/star-fill.svg") !important;
+  mask-image: url("@gouvfr/dsfr/dist/icons/system/star-fill.svg") !important;
+  mask-repeat: no-repeat;
+}
+
+.ac-notice {
+  border-style: solid;
+  border-width: 2px;
+  color: var(--text-action-high-blue-france) !important;
+}
+
+@media screen and (max-width: 993px) {
+  .ac-notice {
+    text-align: center;
+  }
+}
+
+@media screen and (min-width: 993px) {
+  .ac-questionnaire {
+    background-color: (to right, white 50%, pink 50%);
+    background: linear-gradient(
+      to right,
+      white 50%,
+      var(--background-default-grey-hover) 50%
+    );
+  }
+}

--- a/src/views/_layout.ejs
+++ b/src/views/_layout.ejs
@@ -18,6 +18,34 @@
     </div>
     <div id="loader-bar"></div>
     <%- include('partials/header.ejs'); %>
+    <div class="ac-questionnaire">
+        <div class="ac-notice fr-notice fr-notice--info ac-notice--info fr-m-2w">
+          <div class="fr-container">
+            <div class="fr-notice__body">
+              <p>
+                <span class="fr-notice__title ac-notice__title">
+                  <a
+                    target="_blank"
+                    rel="noopener external"
+                    title="Questionnaire de satisfaction ProConnect"
+                    href="https://tally.so/r/mJkV0Y"
+                    class="fr-notice__link"
+                    >Quel est votre avis sur ProConnect ?</a
+                  >
+                </span>
+              </p>
+              <button
+                title="Masquer le message"
+                onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)"
+                id="button-1299"
+                class="fr-btn--close fr-btn"
+              >
+                Masquer le message
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>      
     <% if (locals.use_dashboard_layout) { %>
         <main role="main" id="main" tabindex="-1">
             <%- body; %>


### PR DESCRIPTION
version desktop : 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/45edd422-ee19-4e3c-b350-679b05afd944" />

version mobile : 
<img width="577" alt="image" src="https://github.com/user-attachments/assets/b0fb3ea8-479d-46dc-9c4b-2f6d3668fb28" />

